### PR TITLE
Fix misspelling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This gem generates a script for mscgen. This can generate sequence image(i.e. pn
 ### install mscgen
 
      $ yum install mscgen # Linux(CentOS, Fedora..)
-     $ brew isntall mscgen # MacOS X
+     $ brew install mscgen # MacOS X
 
 
  Install


### PR DESCRIPTION
Noticed a misspelling in the README when I copied the `brew install` command for OS X.
